### PR TITLE
calculate a ts mac and provide it on the TokenExpire exception

### DIFF
--- a/mohawk/exc.py
+++ b/mohawk/exc.py
@@ -52,9 +52,11 @@ class TokenExpired(HawkFail):
 
         The `Hawk`_ spec mentions how you can synchronize
         your sender's time with the receiver in the case
-        of unexpected expiration. However, do not expose a local
-        timestamp in the raw to a sender over HTTP since
-        it can potentially be used for an attack.
+        of unexpected expiration. It is okay to expose the
+        server timestamp in the clear (in the absence of TLS)
+        so long as it is accompanied by a ts mac calculated
+        using the client's credentials and the client verifies
+        the mac prior to applying the offset.
         See the Hawk Node lib for an example of HMAC'ing the
         timestamp to send to clients.
 
@@ -62,9 +64,11 @@ class TokenExpired(HawkFail):
     """
     #: Current local time in seconds that was used to compare timestamps.
     localtime_in_seconds = None
+    www_authenticate = None
 
     def __init__(self, *args, **kw):
         self.localtime_in_seconds = kw.pop('localtime_in_seconds')
+        self.www_authenticate = kw.pop('www_authenticate')
         super(HawkFail, self).__init__(*args, **kw)
 
 

--- a/mohawk/util.py
+++ b/mohawk/util.py
@@ -73,7 +73,25 @@ def calculate_mac(mac_type, resource, content_hash):
 
     if not isinstance(normalized, six.binary_type):
         normalized = normalized.encode('utf8')
-    key = resource.credentials['key']  # e.g. 'sha256'
+    key = resource.credentials['key']
+    if not isinstance(key, six.binary_type):
+        key = key.encode('ascii')
+
+    result = hmac.new(key, normalized, digestmod)
+    return b64encode(result.digest())
+
+
+def calculate_ts_mac(ts, credentials):
+    """Calculates a message authorization code (MAC) for a timestamp."""
+    normalized = ('hawk.{hawk_ver}.ts\n{ts}\n'
+                  .format(hawk_ver=HAWK_VER, ts=ts))
+    log.debug(u'normalized resource for ts mac calc: {norm}'
+              .format(norm=normalized))
+    digestmod = getattr(hashlib, credentials['algorithm'])
+
+    if not isinstance(normalized, six.binary_type):
+        normalized = normalized.encode('utf8')
+    key = credentials['key']
     if not isinstance(key, six.binary_type):
         key = key.encode('ascii')
 


### PR DESCRIPTION
This will allow receivers to send back a secure timestamp so senders can calculate and apply a local timestamp offset on subsequent requests.

It actually creates the WWW-Authenticate header contents of the form

```
Hawk ts="{ts}", tsm="{tsm}", error="{error}"
```

as expected by the sender.

Reference:
https://github.com/hueniverse/hawk/blob/v2.2.0/lib/client.js#L147
https://github.com/hueniverse/hawk/blob/v2.2.0/lib/utils.js#L100

Sorry I didn't write tests, but I thought this could at least get you started.
