### PR TITLE
seen_nonce receives sender's id

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -265,9 +265,9 @@ the timestamp of the message which may result in a
 :class:`mohawk.exc.TokenExpired` exception.
 Second, every message includes a `cryptographic nonce`_
 which is a unique
-identifier. In combination with the timestamp, a receiver can use the nonce to
-know if it has *already* received the request. If so,
-the :class:`mohawk.exc.AlreadyProcessed` exception is raised.
+identifier. In combination with the sender's id and the request's timestamp, a
+receiver can use the nonce to know if it has *already* received the request. If
+so, the :class:`mohawk.exc.AlreadyProcessed` exception is raised.
 
 By default, Mohawk doesn't know how to check nonce values; this is something
 your application needs to do.
@@ -277,13 +277,13 @@ your application needs to do.
     If you don't configure nonce checking, your application could be
     susceptible to replay attacks.
 
-Make a callable that returns True if a nonce plus its timestamp has been
+Make a callable that returns True if a sender's nonce plus its timestamp has been
 seen already. Here is an example using something like memcache:
 
 .. doctest:: usage
 
-    >>> def seen_nonce(nonce, timestamp):
-    ...     key = '{nonce}:{ts}'.format(nonce=nonce, ts=timestamp)
+    >>> def seen_nonce(id, nonce, timestamp):
+    ...     key = '{id}:{nonce}:{ts}'.format(id=id, nonce=nonce, ts=timestamp)
     ...     if memcache.get(key):
     ...         # We have already processed this nonce + timestamp.
     ...         return True

--- a/mohawk/base.py
+++ b/mohawk/base.py
@@ -70,12 +70,14 @@ class HawkAuthority:
                             algo=resource.credentials['algorithm']))
 
         if resource.seen_nonce:
-            if resource.seen_nonce(parsed_header['nonce'],
+            if resource.seen_nonce(resource.credentials['id'],
+                                   parsed_header['nonce'],
                                    parsed_header['ts']):
                 raise AlreadyProcessed('Nonce {nonce} with timestamp {ts} '
-                                       'has already been processed'
+                                       'has already been processed for {id}'
                                        .format(nonce=parsed_header['nonce'],
-                                               ts=parsed_header['ts']))
+                                               ts=parsed_header['ts'],
+                                               id=resource.credentials['id']))
         else:
             log.warn('seen_nonce was None; not checking nonce. '
                      'You may be vulnerable to replay attacks')

--- a/mohawk/tests.py
+++ b/mohawk/tests.py
@@ -29,7 +29,7 @@ class Base(TestCase):
         }
 
         # This callable might be replaced by tests.
-        def seen_nonce(nonce, ts):
+        def seen_nonce(id, nonce, ts):
             return False
         self.seen_nonce = seen_nonce
 
@@ -197,7 +197,7 @@ class TestSender(Base):
     @raises(AlreadyProcessed)
     def test_nonce_fail(self):
 
-        def seen_nonce(nonce, ts):
+        def seen_nonce(id, nonce, ts):
             return True
 
         sn = self.Sender()
@@ -206,7 +206,7 @@ class TestSender(Base):
 
     def test_nonce_ok(self):
 
-        def seen_nonce(nonce, ts):
+        def seen_nonce(id, nonce, ts):
             return False
 
         sn = self.Sender(seen_nonce=seen_nonce)


### PR DESCRIPTION
Breaking change to reflect latest hawk.js spec.

The seen_nonce() function now receives the sender's id in order to avoid false collisions with other requests sharing the same timestamp and nonce values.

Related change in the hawk.js project: hueniverse/hawk#141

This should probably engender at least a minor-version bump to indicate the api change.