### PR TITLE
make sure client id isn't bytes on py3 before doing str ops on it

### DIFF
--- a/mohawk/bewit.py
+++ b/mohawk/bewit.py
@@ -48,7 +48,7 @@ def get_bewit(resource):
     # Oct 28, 2015, so this could break compat.
     # We can leave \ in ext since validators can limit how many \ they split
     # on (although again, the canonical implementation does not do this)
-    client_id = resource.credentials['id']
+    client_id = six.text_type(resource.credentials['id'])
     if "\\" in client_id:
         log.warn("Stripping backslash character(s) '\\' from client_id")
         client_id = client_id.replace("\\", "")

--- a/mohawk/tests.py
+++ b/mohawk/tests.py
@@ -656,6 +656,17 @@ class TestBewit(Base):
         expected = '123456\\1356420707\\IGYmLgIqLrCe8CxvKPs4JlWIA+UjWJJouwgARiVhCAg=\\'
         eq_(b64decode(bewit).decode('ascii'), expected)
 
+    def test_bewit_with_binary_id(self):
+        # Check for exceptions in get_bewit call with binary id
+        binary_credentials = self.credentials.copy()
+        binary_credentials['id'] = binary_credentials['id'].encode('ascii')
+        res = Resource(url='https://example.com/somewhere/over/the/rainbow',
+                       method='GET', credentials=binary_credentials,
+                       timestamp=1356420407 + 300,
+                       nonce='',
+                       )
+        get_bewit(res)
+
     def test_bewit_with_ext(self):
         res = Resource(url='https://example.com/somewhere/over/the/rainbow',
                        method='GET', credentials=self.credentials,


### PR DESCRIPTION
I'm porting taskcluster-client.py to py3, and i hit py3 errors on get_bewit() because the client id is in bytes.
The alternate fix here is for me to str-ize the client id on the tc.py end, but I thought it might be better to make the get_bewit() method able to handle that case.

The skip_missing_interpreters line in tox.ini allows for running tox sans-arguments even if all python interpreters aren't installed.  If that's not the preferred default, I can remove it.