### PR TITLE
Update util.py

### DIFF
--- a/mohawk/tests.py
+++ b/mohawk/tests.py
@@ -320,10 +320,10 @@ class TestSender(Base):
         eq_(parsed['ext'], "new line \n in the middle")
 
     def test_ext_with_equality_sign(self):
-        sn = self.Sender(ext="foo=bar")
+        sn = self.Sender(ext="foo=bar&foo2=bar2;foo3=bar3")
         self.receive(sn.request_header)
         parsed = parse_authorization_header(sn.request_header)
-        eq_(parsed['ext'], "foo=bar")
+        eq_(parsed['ext'], "foo=bar&foo2=bar2;foo3=bar3")
 
     @raises(BadHeaderValue)
     def test_ext_with_illegal_chars(self):

--- a/mohawk/util.py
+++ b/mohawk/util.py
@@ -172,10 +172,8 @@ def parse_authorization_header(auth_header):
             raise HawkFail("Unknown Hawk key '{key}' when parsing header"
                            .format(key=key))
 
-        # TODO we don't do a good job of parsing, '=' should work for more =.
-        # hash or mac value includes '=' character... fixup
-        if len(attr_parts) == 3:
-            attr_parts[1] += '=' + attr_parts[2]
+        if len(attr_parts) > 2:
+            attr_parts[1] = '='.join(attr_parts[1:])
 
         # Chop of quotation marks
         value = attr_parts[1]


### PR DESCRIPTION
This pull requests solves the error of when one of the fields in auth header has more than one equal sign. 

The absence of this feature was problematic for me when i wanted a dictionary stored in the ext field:
```
ext="key1=value1;key2=value2"
```