### PR TITLE
Check MAC before calculating the content-hash (issue #15)

### DIFF
--- a/mohawk/base.py
+++ b/mohawk/base.py
@@ -52,10 +52,7 @@ class HawkAuthority:
             log.info('request unexpectedly did not hash its content')
 
         if check_hash:
-            p_hash = calculate_payload_hash(resource.content,
-                                            resource.credentials['algorithm'],
-                                            resource.content_type)
-            if not strings_match(p_hash, their_hash):
+            if not strings_match(content_hash, their_hash):
                 # The hash declared in the header is incorrect.
                 # Content could have been tampered with.
                 log.debug('mismatched content: {content}'
@@ -65,7 +62,7 @@ class HawkAuthority:
                 raise MisComputedContentHash(
                     'Our hash {ours} ({algo}) did not '
                     'match theirs {theirs}'
-                    .format(ours=p_hash,
+                    .format(ours=content_hash,
                             theirs=their_hash,
                             algo=resource.credentials['algorithm']))
 

--- a/mohawk/base.py
+++ b/mohawk/base.py
@@ -32,11 +32,12 @@ class HawkAuthority:
         now = utc_now(offset_in_seconds=localtime_offset_in_seconds)
 
         their_hash = parsed_header.get('hash', '')
+        their_mac = parsed_header.get('mac', '')
         mac = calculate_mac(mac_type, resource, their_hash)
-        if not strings_match(mac, parsed_header['mac']):
+        if not strings_match(mac, their_mac):
             raise MacMismatch('MACs do not match; ours: {ours}; '
                               'theirs: {theirs}'
-                              .format(ours=mac, theirs=parsed_header['mac']))
+                              .format(ours=mac, theirs=their_mac))
 
         if 'hash' not in parsed_header and accept_untrusted_content:
             # The request did not hash its content.

--- a/mohawk/tests.py
+++ b/mohawk/tests.py
@@ -192,7 +192,7 @@ class TestSender(Base):
         self.receive(sn.request_header,
                      url='http://site.com:8000/foo?bar=1')
 
-    @raises(MacMismatch)
+    @raises(MisComputedContentHash)
     def test_tamper_with_content(self):
         sn = self.Sender()
         self.receive(sn.request_header, content='stuff=nope')
@@ -259,7 +259,7 @@ class TestSender(Base):
         # Without an offset this will raise an expired exception.
         self.receive(sn.request_header, timestamp_skew_in_seconds=120)
 
-    @raises(MisComputedContentHash)
+    @raises(MacMismatch)
     def test_hash_tampering(self):
         sn = self.Sender()
         header = sn.request_header.replace('hash="', 'hash="nope')
@@ -428,13 +428,13 @@ class TestReceiver(Base):
         self.receive(method=method)
         self.respond()
 
-    @raises(MacMismatch)
+    @raises(MisComputedContentHash)
     def test_respond_with_wrong_content(self):
         self.receive()
         self.respond(content='real content',
                      accept_kw=dict(content='TAMPERED WITH'))
 
-    @raises(MacMismatch)
+    @raises(MisComputedContentHash)
     def test_respond_with_wrong_content_type(self):
         self.receive()
         self.respond(content_type='text/html',
@@ -548,14 +548,14 @@ class TestReceiver(Base):
         wrong_sender = self.sender
         self.receive(url='http://realsite.com/', sender=wrong_sender)
 
-    @raises(MacMismatch)
+    @raises(MisComputedContentHash)
     def test_receive_wrong_content(self):
         self.receive(sender_kw=dict(content='real request'),
                      content='real request')
         wrong_sender = self.sender
         self.receive(content='TAMPERED WITH', sender=wrong_sender)
 
-    @raises(MacMismatch)
+    @raises(MisComputedContentHash)
     def test_unexpected_unhashed_content(self):
         self.receive(sender_kw=dict(content=None, content_type=None,
                                     always_hash_content=False))
@@ -574,7 +574,7 @@ class TestReceiver(Base):
                                     content_type='text/plain'),
                      content=content, content_type=None)
 
-    @raises(MacMismatch)
+    @raises(MisComputedContentHash)
     def test_receive_wrong_content_type(self):
         self.receive(sender_kw=dict(content_type='text/html'),
                      content_type='text/html')


### PR DESCRIPTION
There is two commits in this PR:

1. Move the check of the MAC up a few lines and use the header-provided content-hash for checking. (Change expected exceptions accordingly.)
2. Remove the duplicated content-hash calculation. Both invocations of calculate_payload_hash received the _same_ arguments.