### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,12 +14,12 @@ Mohawk
     :alt: Travis master branch status
 
 .. image:: https://readthedocs.org/projects/mohawk/badge/?version=latest
-    :target: https://mohawk.readthedocs.org/en/latest/?badge=latest
+    :target: https://mohawk.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation status
 
 Mohawk is an alternate Python implementation of the
 `Hawk HTTP authorization scheme`_.
 
-Full documentation: https://mohawk.readthedocs.org/
+Full documentation: https://mohawk.readthedocs.io/
 
 .. _`Hawk HTTP authorization scheme`: https://github.com/hueniverse/hawk

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -51,5 +51,5 @@ To publish the new release on `PyPI`_, run this from the repository root::
 
 
 .. _virtualenv: https://pypi.python.org/pypi/virtualenv
-.. _tox: http://tox.readthedocs.org/
+.. _tox: https://tox.readthedocs.io/
 .. _`PyPI`: https://pypi.python.org/pypi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Mohawk is an alternate Python implementation of the
     :alt: Travis master branch status
 
 .. image:: https://readthedocs.org/projects/mohawk/badge/?version=latest
-    :target: https://mohawk.readthedocs.org/en/latest/?badge=latest
+    :target: https://mohawk.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation status
 
 
@@ -56,7 +56,7 @@ Using `pip`_::
 
 If you want to install from source, visit https://github.com/kumar303/mohawk
 
-.. _pip: http://pip.readthedocs.org/
+.. _pip: https://pip.readthedocs.io/
 
 Bugs
 ====
@@ -90,7 +90,7 @@ into specific web frameworks:
 * `Hawkrest`_: adds Hawk to `Django Rest Framework`_
 * Did we miss one? Send a `pull request`_ so we can link to it.
 
-.. _`Hawkrest`: http://hawkrest.readthedocs.org/
+.. _`Hawkrest`: https://hawkrest.readthedocs.io/
 .. _`Django Rest Framework`: http://django-rest-framework.org/
 .. _`pull request`: https://github.com/kumar303/mohawk
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# For info on tox see http://tox.readthedocs.org/
+# For info on tox see https://tox.readthedocs.io/
 
 [tox]
 # Also see .travis.yml where this is maintained separately.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.