### PR TITLE
Use explicit matching for a-z, A-Z and 0-9

### DIFF
--- a/mohawk/util.py
+++ b/mohawk/util.py
@@ -222,10 +222,7 @@ def utc_now(offset_in_seconds=0.0):
 # Allowed value characters:
 # !#$%&'()*+,-./:;<=>?@[]^_`{|}~ and space, a-z, A-Z, 0-9, \, "
 _header_attribute_chars = re.compile(
-    r"^[ \w\!#\$%&'\(\)\*\+,\-\./\:;<\=>\?@\[\]\^`\{\|\}~\"\\]*$",
-    # Here we want to make sure non-ascii chars are excluded from headers per
-    # the Node lib.
-    re.LOCALE)
+    r"^[ a-zA-Z0-9_\!#\$%&'\(\)\*\+,\-\./\:;<\=>\?@\[\]\^`\{\|\}~\"\\]*$")
 
 
 def validate_header_attr(val, name=None):


### PR DESCRIPTION
Swaps `\w` for the more explicit `a-zA-Z0-9`. `\w` also includes `_`, but that is already covered in the regex.

This also drops the re.LOCALE flag, which would cause whatever characters defined by the current locale as alphanumeric to be accepted as valid header values, thus causing potential differences between deployments based on locale settings.

Ref #32 