### PR TITLE
Fix deprecation warnings

### DIFF
--- a/mohawk/base.py
+++ b/mohawk/base.py
@@ -77,8 +77,8 @@ class HawkAuthority:
                                                ts=parsed_header['ts'],
                                                id=resource.credentials['id']))
         else:
-            log.warn('seen_nonce was None; not checking nonce. '
-                     'You may be vulnerable to replay attacks')
+            log.warning('seen_nonce was None; not checking nonce. '
+                        'You may be vulnerable to replay attacks')
 
         their_ts = int(their_timestamp or parsed_header['ts'])
 

--- a/mohawk/bewit.py
+++ b/mohawk/bewit.py
@@ -50,7 +50,7 @@ def get_bewit(resource):
     # on (although again, the canonical implementation does not do this)
     client_id = six.text_type(resource.credentials['id'])
     if "\\" in client_id:
-        log.warn("Stripping backslash character(s) '\\' from client_id")
+        log.warning("Stripping backslash character(s) '\\' from client_id")
         client_id = client_id.replace("\\", "")
 
     # b64encode works only with bytes in python3, but all of our parameters are

--- a/mohawk/tests.py
+++ b/mohawk/tests.py
@@ -733,8 +733,8 @@ class TestBewit(Base):
         url = "https://example.com/somewhere/over/the/rainbow?bewit={bewit}".format(bewit=bewit)
 
         raw_bewit, stripped_url = strip_bewit(url)
-        self.assertEquals(raw_bewit, bewit)
-        self.assertEquals(stripped_url, "https://example.com/somewhere/over/the/rainbow")
+        self.assertEqual(raw_bewit, bewit)
+        self.assertEqual(stripped_url, "https://example.com/somewhere/over/the/rainbow")
 
     @raises(InvalidBewit)
     def test_strip_url_without_bewit(self):
@@ -745,28 +745,28 @@ class TestBewit(Base):
         bewit = b'123456\\1356420707\\IGYmLgIqLrCe8CxvKPs4JlWIA+UjWJJouwgARiVhCAg=\\'
         bewit = urlsafe_b64encode(bewit).decode('ascii')
         bewit = parse_bewit(bewit)
-        self.assertEquals(bewit.id, '123456')
-        self.assertEquals(bewit.expiration, '1356420707')
-        self.assertEquals(bewit.mac, 'IGYmLgIqLrCe8CxvKPs4JlWIA+UjWJJouwgARiVhCAg=')
-        self.assertEquals(bewit.ext, '')
+        self.assertEqual(bewit.id, '123456')
+        self.assertEqual(bewit.expiration, '1356420707')
+        self.assertEqual(bewit.mac, 'IGYmLgIqLrCe8CxvKPs4JlWIA+UjWJJouwgARiVhCAg=')
+        self.assertEqual(bewit.ext, '')
 
     def test_parse_bewit_with_ext(self):
         bewit = b'123456\\1356420707\\IGYmLgIqLrCe8CxvKPs4JlWIA+UjWJJouwgARiVhCAg=\\xandyandz'
         bewit = urlsafe_b64encode(bewit).decode('ascii')
         bewit = parse_bewit(bewit)
-        self.assertEquals(bewit.id, '123456')
-        self.assertEquals(bewit.expiration, '1356420707')
-        self.assertEquals(bewit.mac, 'IGYmLgIqLrCe8CxvKPs4JlWIA+UjWJJouwgARiVhCAg=')
-        self.assertEquals(bewit.ext, 'xandyandz')
+        self.assertEqual(bewit.id, '123456')
+        self.assertEqual(bewit.expiration, '1356420707')
+        self.assertEqual(bewit.mac, 'IGYmLgIqLrCe8CxvKPs4JlWIA+UjWJJouwgARiVhCAg=')
+        self.assertEqual(bewit.ext, 'xandyandz')
 
     def test_parse_bewit_with_ext_and_backslashes(self):
         bewit = b'123456\\1356420707\\IGYmLgIqLrCe8CxvKPs4JlWIA+UjWJJouwgARiVhCAg=\\xand\\yandz'
         bewit = urlsafe_b64encode(bewit).decode('ascii')
         bewit = parse_bewit(bewit)
-        self.assertEquals(bewit.id, '123456')
-        self.assertEquals(bewit.expiration, '1356420707')
-        self.assertEquals(bewit.mac, 'IGYmLgIqLrCe8CxvKPs4JlWIA+UjWJJouwgARiVhCAg=')
-        self.assertEquals(bewit.ext, 'xand\\yandz')
+        self.assertEqual(bewit.id, '123456')
+        self.assertEqual(bewit.expiration, '1356420707')
+        self.assertEqual(bewit.mac, 'IGYmLgIqLrCe8CxvKPs4JlWIA+UjWJJouwgARiVhCAg=')
+        self.assertEqual(bewit.ext, 'xand\\yandz')
 
     @raises(InvalidBewit)
     def test_parse_invalid_bewit_with_only_one_part(self):

--- a/mohawk/tests.py
+++ b/mohawk/tests.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 from unittest import TestCase
 from base64 import b64decode, urlsafe_b64encode
 
@@ -25,6 +26,10 @@ from .bewit import (get_bewit,
                     check_bewit,
                     strip_bewit,
                     parse_bewit)
+
+
+# Ensure deprecation warnings are turned to exceptions
+warnings.filterwarnings('error')
 
 
 class Base(TestCase):


### PR DESCRIPTION
This should be fine, but while fixing this I noticed the removing backslashes thing, which I believe wasn't hit by tests and might be superfluous with the refactored parsing, you might want to check that out.